### PR TITLE
Add help buttons with rule translations

### DIFF
--- a/help.js
+++ b/help.js
@@ -1,0 +1,14 @@
+(function() {
+  const skBtn = document.getElementById('scorekeeper-help');
+  const impBtn = document.getElementById('imposter-help');
+
+  if (skBtn) {
+    skBtn.textContent = t('showRules');
+    skBtn.addEventListener('click', () => alert(t('rulesScorekeeper')));
+  }
+
+  if (impBtn) {
+    impBtn.textContent = t('showRules');
+    impBtn.addEventListener('click', () => alert(t('rulesImposter')));
+  }
+})();

--- a/i18n.js
+++ b/i18n.js
@@ -13,6 +13,9 @@ const translations = {
     scoreAmount: 'Punkte',
     updateScore: 'Speichern',
     remove: 'Spieler entfernen',
+    showRules: '?',
+    rulesScorekeeper: 'Füge Spieler hinzu und notiere nach jeder Runde die Punkte.',
+    rulesImposter: 'Ein Spieler bekommt "IMPOSTER" statt des Wortes. Findet den Betrüger!'
   },
   en: {
     appTitle: 'Games',
@@ -28,5 +31,8 @@ const translations = {
     scoreAmount: 'Points',
     updateScore: 'Apply',
     remove: 'Remove player',
+    showRules: '?',
+    rulesScorekeeper: 'Add players and record points after each round.',
+    rulesImposter: 'One player sees "IMPOSTER" instead of the word. Find out who it is!'
   }
 };

--- a/index.html
+++ b/index.html
@@ -15,23 +15,25 @@
     </select>
   </header>
 
-  <main>
-    <div id="scorekeeper">
-      <section id="player-form">
-        <input type="text" id="player-name" placeholder="Spielername" />
-        <button id="add-player">Spieler hinzufügen</button>
-      </section>
+    <main>
+      <div id="scorekeeper">
+        <button id="scorekeeper-help">?</button>
+        <section id="player-form">
+          <input type="text" id="player-name" placeholder="Spielername" />
+          <button id="add-player">Spieler hinzufügen</button>
+        </section>
 
       <ul id="players"></ul>
 
       <button id="reset">Spiel zurücksetzen</button>
     </div>
 
-    <div id="imposter-game" style="display:none;">
-      <section id="imposter-player-form">
-        <input type="text" id="imposter-player-name" placeholder="Spielername" />
-        <button id="imposter-add-player">Spieler hinzufügen</button>
-      </section>
+      <div id="imposter-game" style="display:none;">
+        <button id="imposter-help">?</button>
+        <section id="imposter-player-form">
+          <input type="text" id="imposter-player-name" placeholder="Spielername" />
+          <button id="imposter-add-player">Spieler hinzufügen</button>
+        </section>
       <button id="imposter-start">Spiel starten</button>
       <div id="imposter-display" style="display:none;">
         <p id="imposter-current"></p>
@@ -47,6 +49,7 @@
   <script src="i18n.js"></script>
   <script src="imposter-data.js"></script>
   <script src="shared.js"></script>
+  <script src="help.js"></script>
   <script src="scorekeeper.js"></script>
   <script src="imposter.js"></script>
 </body>

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@ Eine einfache, mobile-freundliche Webapp mit verschiedenen Minispielen. Alle Dat
 - ✅ Automatischer Darkmode je nach System-Einstellung
 - ✅ Persistente Speicherung über LocalStorage
 - ✅ Mehrsprachige Texte über eine kleine i18n-Datei
+- ✅ "?"-Buttons zeigen die Regeln der Spielmodi an
 
 ## 🚀 Verwendung
 
@@ -33,6 +34,7 @@ Eine einfache, mobile-freundliche Webapp mit verschiedenen Minispielen. Alle Dat
    - Das Spiel kann jederzeit über "Spiel zurücksetzen" neu gestartet werden.
    - Der Startspieler wird zufällig bestimmt.
    - Der Look passt sich automatisch dem hellen oder dunklen System-Design an.
+   - Über die "?"-Buttons lassen sich die Regeln anzeigen.
 
 4. Alle Daten werden automatisch im Browser gespeichert und stehen offline zur Verfügung.
 


### PR DESCRIPTION
## Summary
- include new `showRules`, `rulesScorekeeper` and `rulesImposter` texts
- add help buttons to both game sections
- wire up buttons in new `help.js`
- note rule buttons in README

## Testing
- `node -c help.js`
- `node -c i18n.js`
- `node -c scorekeeper.js`
- `node -c imposter.js`
- `node -c shared.js`


------
https://chatgpt.com/codex/tasks/task_e_688a1e19b4f0832189be906cb371c80c